### PR TITLE
Updates for GHC 8.6

### DIFF
--- a/uu-cco/src/CCO/Feedback.hs
+++ b/uu-cco/src/CCO/Feedback.hs
@@ -61,6 +61,7 @@ instance Monad Feedback where
                            Fail msgs'      -> Fail (msgs ++ msgs')
   Fail msgs      >>= _ = Fail msgs
 
+instance MonadFail Feedback where
   fail msg             = Fail [Error (text msg)]
 
 instance Applicative Feedback where

--- a/uu-cco/src/CCO/Printing/Printer.hs
+++ b/uu-cco/src/CCO/Printing/Printer.hs
@@ -29,6 +29,7 @@ module CCO.Printing.Printer (
   ) where
 
 import CCO.Printing.Colour                ( Colour (..) )
+import Data.Semigroup                     ( Semigroup (..) )
 import Data.Monoid                        ( Monoid (..) )
 import System.Console.ANSI                ( ConsoleLayer (Foreground)
                                           , ColorIntensity (Dull)
@@ -93,6 +94,9 @@ class Monoid a => Printer a where
 -- | The type of printers that produce 'String's.
 data StringPrinter = SP !Int !Int (String -> String)
 
+instance Semigroup StringPrinter where
+  (<>) = mappend
+
 instance Monoid StringPrinter where
   mempty = SP 0 0 id
   mappend (SP wl hl accl) (SP wr hr accr) =
@@ -115,6 +119,9 @@ printToString (SP _ _ acc) = acc ""
 
 -- | The type of printers that print to the standard output channel.
 data IOPrinter = IOP !Int !Int ([Colour] -> (IO (), [Colour]))
+
+instance Semigroup IOPrinter where
+  (<>) = mappend
 
 instance Monoid IOPrinter where
   mempty                              = IOP 0 0 (\cs -> (return (), cs))

--- a/uu-cco/uu-cco.cabal
+++ b/uu-cco/uu-cco.cabal
@@ -1,5 +1,5 @@
 name:                  uu-cco
-version:               0.1.0.5
+version:               0.1.0.6
 synopsis:              Utilities for compiler construction: core functionality
 description:           A small utility library accompanying the course on
                        Compiler Construction (INFOMCCO) at Utrecht Univerity.


### PR DESCRIPTION
Semigroup instances required for Monoids